### PR TITLE
Enable opening of generated pdf within Linux, Windows

### DIFF
--- a/src/lwb/vis.clj
+++ b/src/lwb/vis.clj
@@ -153,7 +153,7 @@
          sys-name (System/getProperty "os.name")]
      (spit (str filename ".tex") tex-code)
      (shell/sh "texi2pdf" (str filename ".tex"))
-     (condp str/includes? sys-name
+     (condp #(str/includes? %2 %1) sys-name
        "Linux" (shell/sh "xdg-open" (str filename ".pdf"))
        "Mac" (shell/sh "open" (str filename ".pdf"))
        "Windows" (shell/sh "start" (str filename ".pdf"))))))

--- a/src/lwb/vis.clj
+++ b/src/lwb/vis.clj
@@ -149,8 +149,11 @@
    (let [tikz-body (vis-tikz-body phi)]
      (str tikz-header "\n" tikz-body "\n" tikz-footer)))
   ([phi filename]
-   (let [tex-code (texify phi)]
+   (let [tex-code (texify phi)
+         sys-name (System/getProperty "os.name")]
      (spit (str filename ".tex") tex-code)
      (shell/sh "texi2pdf" (str filename ".tex"))
-     (shell/sh "open" (str filename ".pdf")))))
-
+     (condp str/includes? sys-name
+       "Linux" (shell/sh "xdg-open" (str filename ".pdf"))
+       "Mac" (shell/sh "open" (str filename ".pdf"))
+       "Windows" (shell/sh "start" (str filename ".pdf"))))))


### PR DESCRIPTION
This pull request enables opening the generated pdf file from `texify` on Linux and Windows by using the  platform specific command. The equivalent to OSX's `open` is `xdg-open` in Linux and `start` in Windows.

Tested this in OSX and Linux.